### PR TITLE
feat: use auto_renew_altcoin from naming

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: CI Tests
 on: [push, pull_request, pull_request_target]
 
 env:
-  SCARB_VERSION: 0.7.0
+  SCARB_VERSION: 2.3.1
 
 jobs:
   scarb-tests:

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 [dependencies]
 starknet = "2.3.1"
 identity = { git = "https://github.com/starknet-id/identity.git", rev = "eb37846330b78e1410cf5e3e17a5dcca5652f921" }
-naming = { git = "https://github.com/starknet-id/naming.git", rev = "refs/pull/22/head" }
+naming = { git = "https://github.com/starknet-id/naming.git", rev = "6a922ce0e909f5f5d82998ba5c65c86c38c827dd" }
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "f3e2a5f0547a429c716f32471b06df729cbdfb9f" }
 
 [[target.starknet-contract]]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -3,9 +3,9 @@ name = "auto_renew_contract"
 version = "0.1.0"
 
 [dependencies]
-starknet = "2.2.0"
+starknet = "2.3.1"
 identity = { git = "https://github.com/starknet-id/identity.git", rev = "eb37846330b78e1410cf5e3e17a5dcca5652f921" }
-naming = { git = "https://github.com/starknet-id/naming.git", rev = "7edd27a0b5aa0c7118b5d5995c05e05ae4624d29" }
+naming = { git = "https://github.com/starknet-id/naming.git", rev = "refs/pull/22/head" }
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "f3e2a5f0547a429c716f32471b06df729cbdfb9f" }
 
 [[target.starknet-contract]]

--- a/src/auto_renewal.cairo
+++ b/src/auto_renewal.cairo
@@ -388,7 +388,7 @@ mod AutoRenewal {
             // if something remains after this, it can be considered as lost by the user,
             // we keep the ability to claim it back but can't guarantee we will do it
             INamingDispatcher { contract_address: naming }
-                .renew(root_domain, 365_u16, ContractAddressZeroable::zero(), 0, metadata);
+                .auto_renew_altcoin(root_domain, 365_u16, ContractAddressZeroable::zero(), 0, metadata, erc20, domain_price);
         }
     }
 }

--- a/src/tests/test_renewals.cairo
+++ b/src/tests/test_renewals.cairo
@@ -62,6 +62,8 @@ fn test_renew_domain() {
     let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
     testing::set_block_timestamp(BLOCK_TIMESTAMP());
     let token_id: u128 = 1;
+    // whitelist autorenewal contract in the naming
+    naming.whitelist_renewal_contract(autorenewal.contract_address);
 
     // buy TH0RGAL_DOMAIN for a year
     testing::set_contract_address(ADMIN());
@@ -96,6 +98,8 @@ fn test_batch_renew_domain() {
     testing::set_block_timestamp(BLOCK_TIMESTAMP());
     let token_id1: u128 = 1;
     let token_id2: u128 = 2;
+    // whitelist autorenewal contract in the naming
+    naming.whitelist_renewal_contract(autorenewal.contract_address);
 
     // buy TH0RGAL_DOMAIN for a year
     testing::set_contract_address(ADMIN());
@@ -157,9 +161,9 @@ fn test_renew_fail_not_toggled() {
 #[test]
 #[available_gas(20000000)]
 #[should_panic(
-    expected: ('u256_sub Overflow', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED')
+    expected: ('Caller not whitelisted', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED')
 )]
-fn test_renew_fail_wrong_allowance() {
+fn test_renew_fail_not_whitelisted() {
     // initialize contracts
     let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
     let token_id: u128 = 1;
@@ -175,12 +179,11 @@ fn test_renew_fail_wrong_allowance() {
     testing::set_block_timestamp(BLOCK_TIMESTAMP_ADD());
 
     // Toggle renewal for a allowance
-    let lower_price: u256 = 300.into();
-    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), lower_price, 0);
+    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), price, 0);
     erc20.approve(autorenewal.contract_address, integer::BoundedInt::max());
 
     // Should revert because price of renewing domain is higher than limit price
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), lower_price, 0, 0);
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
 }
 
 #[test]
@@ -212,6 +215,8 @@ fn test_renew_expired_domain() {
     // initialize contracts
     let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
     let token_id: u128 = 1;
+    // whitelist autorenewal contract in the naming
+    naming.whitelist_renewal_contract(autorenewal.contract_address);
 
     testing::set_block_timestamp(BLOCK_TIMESTAMP());
 
@@ -245,6 +250,8 @@ fn test_renew_domains() {
     let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
     let token_id: u128 = 1;
     let token_id2: u128 = 2;
+    // whitelist autorenewal contract in the naming
+    naming.whitelist_renewal_contract(autorenewal.contract_address);
 
     testing::set_block_timestamp(BLOCK_TIMESTAMP());
 
@@ -288,6 +295,8 @@ fn test_renew_with_metadata() {
     let metadata = 222222;
     let tax_price: u256 = 100;
     testing::set_block_timestamp(BLOCK_TIMESTAMP());
+    // whitelist autorenewal contract in the naming
+    naming.whitelist_renewal_contract(autorenewal.contract_address);
 
     // buy TH0RGAL_DOMAIN & OTHER_DOMAIN
     testing::set_contract_address(ADMIN());
@@ -330,6 +339,8 @@ fn test_renew_with_updated_whitelisted_renewer() {
     let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
     testing::set_block_timestamp(BLOCK_TIMESTAMP());
     let token_id: u128 = 1;
+    // whitelist autorenewal contract in the naming
+    naming.whitelist_renewal_contract(autorenewal.contract_address);
 
     // buy TH0RGAL_DOMAIN for a year
     testing::set_contract_address(ADMIN());

--- a/src/tests/test_renewals.cairo
+++ b/src/tests/test_renewals.cairo
@@ -160,34 +160,6 @@ fn test_renew_fail_not_toggled() {
 
 #[test]
 #[available_gas(20000000)]
-#[should_panic(
-    expected: ('Caller not whitelisted', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED')
-)]
-fn test_renew_fail_not_whitelisted() {
-    // initialize contracts
-    let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
-    let token_id: u128 = 1;
-    testing::set_block_timestamp(BLOCK_TIMESTAMP());
-
-    // buy TH0RGAL_DOMAIN for a year
-    testing::set_contract_address(ADMIN());
-    let (_, price) = pricing.compute_buy_price(7, 365);
-    erc20.approve(naming.contract_address, price);
-    starknetid.mint(token_id);
-    naming.buy(token_id, TH0RGAL_DOMAIN(), 365_u16, ZERO(), ZERO(), 0, 0);
-
-    testing::set_block_timestamp(BLOCK_TIMESTAMP_ADD());
-
-    // Toggle renewal for a allowance
-    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), price, 0);
-    erc20.approve(autorenewal.contract_address, integer::BoundedInt::max());
-
-    // Should revert because price of renewing domain is higher than limit price
-    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
-}
-
-#[test]
-#[available_gas(20000000)]
 #[should_panic(expected: ('Domain already renewed', 'ENTRYPOINT_FAILED',))]
 fn test_renew_fail_expiry() {
     // initialize contracts
@@ -458,5 +430,33 @@ fn test_renew_disabled_contract_fails() {
 
     autorenewal.toggle_off();
 
+    autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(
+    expected: ('Caller not whitelisted', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED')
+)]
+fn test_renew_fail_not_whitelisted() {
+    // initialize contracts
+    let (erc20, pricing, starknetid, naming, autorenewal) = deploy_contracts();
+    let token_id: u128 = 1;
+    testing::set_block_timestamp(BLOCK_TIMESTAMP());
+
+    // buy TH0RGAL_DOMAIN for a year
+    testing::set_contract_address(ADMIN());
+    let (_, price) = pricing.compute_buy_price(7, 365);
+    erc20.approve(naming.contract_address, price);
+    starknetid.mint(token_id);
+    naming.buy(token_id, TH0RGAL_DOMAIN(), 365_u16, ZERO(), ZERO(), 0, 0);
+
+    testing::set_block_timestamp(BLOCK_TIMESTAMP_ADD());
+
+    // Toggle renewal for a allowance
+    autorenewal.enable_renewals(TH0RGAL_DOMAIN(), price, 0);
+    erc20.approve(autorenewal.contract_address, integer::BoundedInt::max());
+
+    // Should revert because price of renewing domain is higher than limit price
     autorenewal.renew(TH0RGAL_DOMAIN(), ADMIN(), price, 0, 0);
 }


### PR DESCRIPTION
This PR : 
- updates the `_renew` function to use the new `auto_renew_altcoin` from the naming contract. It requires 2 additional arguments : the erc20 contract address and the price of the domain
- updates the tests to whitelist the auto renewal contract in the naming contract
- adds a new test to check that an auto renewal contract that is not whitelisted cannot renew domains. 
- Removes the test `test_renew_fail_wrong_allowance` as it's not relevant anymore. The `price` that is passed into the function will be the actual price, validated by the server, whereas before the naming was fetching the price from the pricing contract, if the price fetched from the pricing contract was higher than the limit price of the user then it resulted in a `u256_sub Overflow` error